### PR TITLE
feat: validates input

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -413,6 +413,8 @@ version = "0.1.0"
 dependencies = [
  "lambda_http",
  "lambda_runtime",
+ "serde",
+ "serde_json",
  "tokio",
  "tracing",
  "tracing-subscriber",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,5 @@ lambda_runtime = "0.6.0"
 tokio = { version = "1", features = ["macros"] }
 tracing = { version = "0.1", features = ["log"] }
 tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt"] }
+serde = { version = "1", features = ["derive", "rc"] }
+serde_json = "1.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,32 @@
 use lambda_http::{run, service_fn, Body, Error, Request, RequestExt, Response};
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize)]
+struct TopicRequestBody {
+    topic: String,
+}
 
 async fn function_handler(event: Request) -> Result<Response<Body>, Error> {
-    let resp = Response::builder()
-        .status(200)
-        .header("content-type", "text/json")
-        .body("{\"hello\": \"world\"}".into())
-        .map_err(Box::new)?;
-    Ok(resp)
+    let invalid_payload_response = Response::builder()
+        .status(400)
+        .body("Invalid payload".into())
+        .expect("failed to render response");
+    if let Body::Text(body) = event.body() {
+        match serde_json::from_str::<TopicRequestBody>(&body) {
+            Ok(topic_body) => {
+                let _ = topic_body.topic;
+                let resp = Response::builder()
+                    .status(200)
+                    .header("content-type", "text/json")
+                    .body("{\"result\": \"posted result on SNS\"}".into())
+                    .map_err(Box::new)?;
+                Ok(resp)
+            }
+            Err(_) => Ok(invalid_payload_response)
+        }
+    } else {
+        Ok(invalid_payload_response)
+    }
 }
 
 #[tokio::main]

--- a/src/test_apigw_proxy_request.json
+++ b/src/test_apigw_proxy_request.json
@@ -32,7 +32,7 @@
     "time": "12/Mar/2020:19:03:58 +0000",
     "timeEpoch": 1583348638390
   },
-  "body": "Hello from Lambda",
+  "body": "{\"topic\":\"test-topic\"}",
   "pathParameters": {"parameter1": "value1"},
   "isBase64Encoded": false,
   "stageVariables": {"stageVariable1": "value1", "stageVariable2": "value2"}

--- a/src/test_apigw_proxy_request_invalid_input.json
+++ b/src/test_apigw_proxy_request_invalid_input.json
@@ -1,0 +1,40 @@
+{
+    "version": "2.0",
+    "routeKey": "$default",
+    "rawPath": "/my/path",
+    "rawQueryString": "parameter1=value1&parameter1=value2&parameter2=value",
+    "cookies": [ "cookie1=value1", "cookie2=value2" ],
+    "headers": {
+      "Header1": "value1",
+      "Header2": "value2"
+    },
+    "queryStringParameters": { "parameter1": "value1,value2", "parameter2": "value" },
+    "requestContext": {
+      "accountId": "123456789012",
+      "apiId": "api-id",
+      "authorizer": { "jwt": {
+          "claims": {"claim1": "value1", "claim2": "value2"},
+          "scopes": ["scope1", "scope2"]
+          }
+      },
+      "domainName": "id.execute-api.us-east-1.amazonaws.com",
+      "domainPrefix": "id",
+      "http": {
+        "method": "POST",
+        "path": "/my/path",
+        "protocol": "HTTP/1.1",
+        "sourceIp": "IP",
+        "userAgent": "agent"
+      },
+      "requestId": "id",
+      "routeKey": "$default",
+      "stage": "$default",
+      "time": "12/Mar/2020:19:03:58 +0000",
+      "timeEpoch": 1583348638390
+    },
+    "body": "invalid this is not json",
+    "pathParameters": {"parameter1": "value1"},
+    "isBase64Encoded": false,
+    "stageVariables": {"stageVariable1": "value1", "stageVariable2": "value2"}
+  }
+  

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -10,5 +10,17 @@ async fn test_lambda() {
   let response = function_handler(request).await.expect("failed to handle request");
 
   assert_eq!(response.status(), 200);
-  assert_eq!(response.into_body(), "{\"hello\": \"world\"}".into());
+  assert_eq!(response.into_body(), "{\"result\": \"posted result on SNS\"}".into());
+}
+
+#[tokio::test]
+async fn test_invalid_input() {
+  let input = include_str!("test_apigw_proxy_request_invalid_input.json");
+
+  let request = lambda_http::request::from_str(input)
+    .expect("failed to create request");
+
+  let response = function_handler(request).await.expect("failed to handle request");
+
+  assert_eq!(response.status(), 400);
 }


### PR DESCRIPTION
validates the payload and maps it into a `TopicRequestBody` object.

# Testing
Functional tests